### PR TITLE
fix typo on app spinner import

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
 <script>
 import { mapActions } from "vuex";
 import TheHeader from "@/components/TheHeader.vue";
-import AppSpinner from "@/components/AppDate.vue";
+import AppSpinner from "@/components/AppSpinner.vue";
 import NProgress from "nprogress";
 
 export default {


### PR DESCRIPTION
Looks like you accidently imported the AppDate as the AppSpinner :) 